### PR TITLE
Fix ToRaw() method in hostlines

### DIFF
--- a/hosts_test.go
+++ b/hosts_test.go
@@ -217,3 +217,19 @@ func TestHostsLineWithTrailingComment(t *testing.T) {
 		}
 	}
 }
+
+func TestHostsLineWithComments(t *testing.T) {
+	hosts := new(Hosts)
+	hosts.Lines = []HostsLine{
+		NewHostsLine("#This is the first comment"),
+		NewHostsLine("127.0.0.1 prada"),
+		NewHostsLine("#This is the second comment"),
+		NewHostsLine("127.0.0.2 tada #HostLine with trailing comment"),
+		NewHostsLine("#This is third comment"),
+	}
+	for _, hostLine := range hosts.Lines {
+		if hostLine.ToRaw() != hostLine.Raw {
+			t.Errorf("Conversion to Raw String Failed")
+		}
+	}
+}

--- a/hostsline.go
+++ b/hostsline.go
@@ -47,6 +47,10 @@ func NewHostsLine(raw string) HostsLine {
 
 func (l *HostsLine) ToRaw() string {
 	var comment string
+	if l.IsComment() { //Whole line is comment
+		return l.Raw
+	}
+
 	if l.Comment != "" {
 		comment = fmt.Sprintf(" %s%s", commentChar, l.Comment)
 	}


### PR DESCRIPTION
Each call to Flush() rewrites the hosts file with the content .

Earlier ToRaw() method used in Flush() to format lines before writing was ignoring comments.
Added check to include comments