### PR TITLE
Unbundle clean operations and refactor RemoveByHostname

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -187,15 +187,15 @@ func (h *Hosts) Remove(ip string, hosts ...string) error {
 
 // Remove  entries by hostname from the hosts file.
 func (h *Hosts) RemoveByHostname(host string) error {
-	newLines := new []HostLines
-	for pos, line := range h.Lines {
+	newLines := []HostsLine{}
+	for _, line := range h.Lines {
 		if len(line.Hosts) > 0 {
 			line.Hosts = removeFromSlice(host, line.Hosts)
 			line.RegenRaw()
 		}
 
 		if len(line.Hosts) > 0 {
-			append(line, newLines)
+			_ = append(newLines, line)
 		}
 	}
 	h.Lines = newLines

--- a/hosts.go
+++ b/hosts.go
@@ -128,11 +128,8 @@ func (h *Hosts) Add(ip string, hosts ...string) error {
 // merge dupelicate ips and hosts per ip
 func (h *Hosts) Clean() {
 	h.RemoveDuplicateIps()
-	for pos, line := range h.Lines {
-		line.RemoveDuplicateHosts()
-		line.SortHosts()
-		h.Lines[pos] = line
-	}
+	h.RemoveDuplicateHosts()
+	h.SortHosts()
 	h.SortByIp()
 	h.HostsPerLine(HostsPerLine)
 }
@@ -190,16 +187,18 @@ func (h *Hosts) Remove(ip string, hosts ...string) error {
 
 // Remove  entries by hostname from the hosts file.
 func (h *Hosts) RemoveByHostname(host string) error {
-	pos := h.getHostnamePosition(host)
-	for pos > -1 {
-		if len(h.Lines[pos].Hosts) > 1 {
-			h.Lines[pos].Hosts = removeFromSlice(host, h.Lines[pos].Hosts)
-			h.Lines[pos].RegenRaw()
-		} else {
-			h.removeByPosition(pos)
+	newLines := new []HostLines
+	for pos, line := range h.Lines {
+		if len(line.Hosts) > 0 {
+			line.Hosts = removeFromSlice(host, line.Hosts)
+			line.RegenRaw()
 		}
-		pos = h.getHostnamePosition(host)
+
+		if len(line.Hosts) > 0 {
+			append(line, newLines)
+		}
 	}
+	h.Lines = newLines
 
 	return nil
 }
@@ -223,6 +222,20 @@ func (h *Hosts) RemoveDuplicateIps() {
 		if count > 1 {
 			h.combineIp(ip)
 		}
+	}
+}
+
+func (h *Hosts) RemoveDuplicateHosts() {
+	for pos, line := range h.Lines {
+		line.RemoveDuplicateHosts()
+		h.Lines[pos] = line
+	}
+}
+
+func (h *Hosts) SortHosts() {
+	for pos, line := range h.Lines {
+		line.SortHosts()
+		h.Lines[pos] = line
 	}
 }
 

--- a/hosts.go
+++ b/hosts.go
@@ -195,7 +195,7 @@ func (h *Hosts) RemoveByHostname(host string) error {
 		}
 
 		if len(line.Hosts) > 0 {
-			_ = append(newLines, line)
+			newLines = append(newLines, line)
 		}
 	}
 	h.Lines = newLines

--- a/hosts_test.go
+++ b/hosts_test.go
@@ -170,13 +170,14 @@ func TestHostsRemoveByHostnameWhenHostnameNotExist(t *testing.T) {
 	if err := hosts.RemoveByHostname("yadda"); err != nil {
 		t.Error(err)
 	}
+
 	// We shouldn't find this entry
 	if hosts.HasHostname("yadda") {
 		t.Error("Found entry that isn't in hosts file.")
 	}
 
 	if !hosts.HasHostname("prada") {
-		t.Error("Found entry that is in hosts file.")
+		t.Error("Did not find entry that is in hosts file.")
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -15,12 +15,21 @@ func itemInSlice(item string, list []string) bool {
 }
 
 func removeFromSlice(s string, slice []string) []string {
-	for key, value := range slice {
-		if value == s {
-			return append(slice[:key], slice[key+1:]...)
+	pos := findPositionInSlice(s, slice)
+	for pos > -1 {
+		slice = append(slice[:pos], slice[pos+1:]...)
+		pos = findPositionInSlice(s, slice)
+	}
+	return slice
+}
+
+func findPositionInSlice(s string, slice []string) int {
+	for index, v := range slice {
+		if v == s {
+			return index
 		}
 	}
-	return nil
+	return -1
 }
 
 //func sliceContainsItem(item string, list []string) bool {

--- a/utils_test.go
+++ b/utils_test.go
@@ -24,7 +24,7 @@ func TestRemoveFromSlice(t *testing.T) {
 	item := "why"
 	list := []string{"why", "hello", "there"}
 	removeFromSlice("why", list)
-	result :=itemInSlice("why", list)
+	result := itemInSlice("why", list)
 	if result {
 		t.Error(fmt.Sprintf("'%s' should not have been found in slice.", item))
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -19,3 +19,25 @@ func TestItemInSlice(t *testing.T) {
 		t.Error(fmt.Sprintf("'%s' should have been found in slice.", item))
 	}
 }
+
+func TestRemoveFromSlice(t *testing.T) {
+	item := "why"
+	list := []string{"why", "hello", "there"}
+	removeFromSlice("why", list)
+	result :=itemInSlice("why", list)
+	if result {
+		t.Error(fmt.Sprintf("'%s' should not have been found in slice.", item))
+	}
+
+	item = "hello"
+	result = itemInSlice(item, list)
+	if !result {
+		t.Error(fmt.Sprintf("'%s' should have been found in slice.", item))
+	}
+
+	item = "there"
+	result = itemInSlice(item, list)
+	if !result {
+		t.Error(fmt.Sprintf("'%s' should have been found in slice.", item))
+	}
+}


### PR DESCRIPTION
This does the following:

 - if a hosts line has a single host then hostname removal does not occur, even if that single host is the one we want to eliminate
 - there's no reason to loop through the whole slice multiple times looking for a position, just do it once, and create a new slice as we iterate
 - it's now possible to de-dupe hosts without sorting in a single step which should make more specific --clean parameters in the cli package easier to implement