### PR TITLE
Implement AddHostPerLine function

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -129,6 +129,23 @@ func (h *Hosts) Add(ip string, hosts ...string) error {
 	return nil
 }
 
+// AddHostPerLine adds entry of the host in separate line.
+func (h *Hosts) AddHostPerLine(ip string, hosts ...string) error {
+	if net.ParseIP(ip) == nil {
+		return fmt.Errorf("%q is an invalid IP address", ip)
+	}
+
+	for _, host := range hosts {
+		// ip not already in hostsfile
+		h.Lines = append(h.Lines, HostsLine{
+			Raw:   buildRawLine(ip, []string{host}),
+			IP:    ip,
+			Hosts: []string{host},
+		})
+	}
+	return nil
+}
+
 // merge dupelicate ips and hosts per ip
 func (h *Hosts) Clean() {
 	h.RemoveDuplicateIps()

--- a/hosts_test.go
+++ b/hosts_test.go
@@ -255,3 +255,20 @@ func TestHostsClean(t *testing.T) {
 		t.Errorf("Clean did not update Raw properly: %s", hosts.Lines[0].ToRaw())
 	}
 }
+
+func TestAddHostPerLine(t *testing.T) {
+	hosts := new(Hosts)
+	hosts.Lines = []HostsLine{
+		NewHostsLine("127.0.0.1 yadda")}
+
+	if err := hosts.AddHostPerLine("10.0.0.7", "nada", "brada", "yadda"); err != nil {
+		t.Error(err)
+	}
+
+	expectedLines := []HostsLine{
+		NewHostsLine("127.0.0.1 yadda"), NewHostsLine("10.0.0.7 nada"), NewHostsLine("10.0.0.7 brada"), NewHostsLine("10.0.0.7 yadda")}
+
+	if !reflect.DeepEqual(hosts.Lines, expectedLines) {
+		t.Error("Add entry failed to append entry.")
+	}
+}


### PR DESCRIPTION
This will try to solve the issue which windows user
is having where they can't have more than 9 hosts for single
IP.

- https://github.com/goodhosts/hostsfile/issues/18
- https://github.com/code-ready/crc/issues/2710

This patch will not break existing Add function so the consumer
of this library have a way to consume either of this function as
per need.