### PR TITLE
Fix #18

### DIFF
--- a/hosts.go
+++ b/hosts.go
@@ -124,6 +124,7 @@ func (h *Hosts) Add(ip string, hosts ...string) error {
 		}
 		h.Lines[position].Hosts = hostsCopy
 		h.Lines[position].Raw = h.Lines[position].ToRaw() // reset raw
+		h.HostsPerLine(HostsPerLine)
 	}
 
 	return nil


### PR DESCRIPTION
Second attempt at trying to fix this that hopefully addresses the feedback from my last attempt.

The issue being that the only time it checks how many are on the same line is during a clean, otherwise it doesn't check this during the Add routine allowing it to happen sometimes