### PR TITLE
utils: Add +build directive

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,4 +1,5 @@
 //go:build !windows
+//+build !windows
 
 package hostsfile
 


### PR DESCRIPTION
go:build is new in golang 1.17, since it also supports the older +build
directive, we can add both. This makes it possible to build
goodhosts/hostsfile with golang 1.16