### PR TITLE
Add batch check methods, safety features, and bug fixes

### DIFF
--- a/hostsline.go
+++ b/hostsline.go
@@ -24,9 +24,9 @@ func NewHostsLine(raw string) HostsLine {
 	output := HostsLine{Raw: raw}
 
 	if output.HasComment() { //trailing comment
-		commentSplit := strings.Split(output.Raw, commentChar)
-		raw = commentSplit[0]
-		output.Comment = commentSplit[1]
+		idx := strings.Index(output.Raw, commentChar)
+		raw = output.Raw[:idx]
+		output.Comment = output.Raw[idx+1:]
 	}
 
 	if output.IsComment() { //whole line is comment

--- a/hostsline_test.go
+++ b/hostsline_test.go
@@ -24,3 +24,23 @@ func TestHosts_combine(t *testing.T) {
 	hl2.Combine(hl1) // should have dupes removed
 	assert.Equal(t, "127.0.0.1 test2 test1 test2", hl2.String())
 }
+
+func TestHostsline_CommentWithMultipleHashes(t *testing.T) {
+	// Test that comments with multiple # characters are preserved correctly
+	raw := "127.0.0.1 localhost # comment with # symbol in it"
+	hl := NewHostsLine(raw)
+
+	assert.Equal(t, "127.0.0.1", hl.IP)
+	assert.Equal(t, []string{"localhost"}, hl.Hosts)
+	assert.Equal(t, " comment with # symbol in it", hl.Comment)
+	assert.Equal(t, raw, hl.ToRaw())
+
+	// Test another case
+	raw2 := "192.168.1.1 host1 host2 # first # second # third"
+	hl2 := NewHostsLine(raw2)
+
+	assert.Equal(t, "192.168.1.1", hl2.IP)
+	assert.Equal(t, []string{"host1", "host2"}, hl2.Hosts)
+	assert.Equal(t, " first # second # third", hl2.Comment)
+	assert.Equal(t, raw2, hl2.ToRaw())
+}


### PR DESCRIPTION
Some changes to support checking hosts before attempting to modify files with `sudo`, and attempting to fix some edge cases around host file comments and race conditions.

Features added:
- HasAll(): Check if IP has all specified hostnames
- HasAny(): Check if IP has any of specified hostnames
- CheckAll(): Get map of hostname existence status
- Backup(): Create backup before modifying hosts file
- BackupTo(): Create backup to custom location
- HasBeenModified(): Detect concurrent modifications

Bug fixes:
- Fix comment parsing to preserve multiple # characters

Safety improvements:
- Add modTime tracking for modification detection
- Enable pre-write safety checks

Tests:
- Add tests for new features
- Add regression test for multi-# comment parsing